### PR TITLE
Load both error modifications and the rest of modifications loaded after error modifications without reading error routes data. Only add error routes back in the end as the last modification

### DIFF
--- a/bus_routes_fixer/bus_routes_fixer.py
+++ b/bus_routes_fixer/bus_routes_fixer.py
@@ -49,10 +49,10 @@ class BusRoutesFixer:
         self.scenario_management_project.add_routes_back()
 
         # Take a screenshot of each error route in the error modification
-        self.scenario_management_project.take_screenshots_in_error_modifications()
+        self.scenario_management_project.take_screenshots_in_modifications()
 
         ###### SAVE TO SCENARIO MANAGEMENT:
-        self.scenario_management_project.save_to_scenario_manager(self.scenario_management_project.pre_error_modifications_list, self.scenario_management_project.after_error_modifications_list)
+        self.scenario_management_project.save_to_scenario_manager(self.scenario_management_project.list_of_mods_pre_1st_error, self.scenario_management_project.list_of_mods_from_1st_error)
 
         # close the visum instances
         self.close()

--- a/bus_routes_fixer/config/directories_P6_Example.json
+++ b/bus_routes_fixer/config/directories_P6_Example.json
@@ -1,10 +1,10 @@
 {
-  "base_path": "bus_routes_fixer/outputs/bus_route_fixer_temp_files",
-  "error_modification_ids": "005, 006",
+  "base_path": "bus_routes_fixer/outputs/temp_files",
+  "id_of_the_1st_error_modification": "005",
   "error_scenario_id": "005",
   "scenario_management_base_path": "C:/Users/Shanshan Xie/TfL/06 Scenario management/00_Bus_Routes_Fixer_Test_P6_Model",
   "scenario_management_project_path": "C:/Users/Shanshan Xie/TfL/06 Scenario management/00_Bus_Routes_Fixer_Test_P6_Model/00_Bus_Routes_Fixer_Test_P6_Model.vpdbx",
   "visum_version": 25,
-  "_note1": "Please refer to the error scenario's message and specify scenario_management_base_path, error_modification_ids & error_scenario_id.",
-  "_note2": "NOTE THAT IF THERE ARE MULTIPLE MODIFICATIONS THAT CAUSED BUS ROUTE ERRORS, LIST ALL OF THEM IN THE ERROR_MODIFICATION_IDS, WITH THE LOADING ORDER OF THESE MODIFICATIONS' IN SCENARIO MANAGEMENT, WITH A COMMA TO SEPARATE EACH TWO MODIFICATION IDS."
+  "_note1": "Please refer to the error scenario's message and specify scenario_management_base_path, id_of_the_1st_error_modification & error_scenario_id.",
+  "_note2": "NOTE THAT IF THERE ARE MULTIPLE MODIFICATIONS THAT CAUSED BUS ROUTE ERRORS, ONLY CHECK THE FIRST ERROR_MODIFICATION_ID."
 }

--- a/bus_routes_fixer/directory_config.py
+++ b/bus_routes_fixer/directory_config.py
@@ -47,7 +47,7 @@ class DirectoryConfig:
         self.scenarios_path = Path(self.scenario_management_base_path) / "Scenarios"
 
         # Clear files in the screenshots folder if it exists
-        self.screenshots_path = current_path / 'bus_routes_screenshots'
+        self.screenshots_path = current_path / 'bus_routes_fixer/outputs/bus_routes_screenshots'
         if os.path.exists(self.screenshots_path):
             for filename in os.listdir(self.screenshots_path):
                 file_path = os.path.join(self.screenshots_path, filename)
@@ -78,16 +78,14 @@ class DirectoryConfig:
                         shutil.rmtree(file_path)
                 except Exception as e:
                     logging.error(f'Failed to delete {file_path}. Reason: {e}')
-        else:
-            logging.info(f'The path {self.bus_routes_fix_path} does not exist.')
 
         # Create the base path if it does not exist
         Path(self.bus_routes_fix_path).mkdir(exist_ok=True, parents=True)
 
         # Assign IDs
         self.error_scenario_id = directories["error_scenario_id"]
-        self.error_modification_ids_str = directories["error_modification_ids"]
-        self.error_modification_ids = [str(int(x.strip())).zfill(6) for x in self.error_modification_ids_str.split(',')]
+        self.first_error_modification_id_str = directories["id_of_the_1st_error_modification"]
+        self.first_error_modification_id = str(int(self.first_error_modification_id_str.strip())).zfill(6)
 
         # Define specific files using relative paths
         self.scenario_management_path = self.scenario_management_base_path / '00_Bus_Routes_Fixer_Test_P6_Model.vpdbx'
@@ -102,15 +100,6 @@ class DirectoryConfig:
         self.route_fixed_transfer_path = self.bus_routes_fix_path / 'fixedRouteAddedTransfer.tra'
         self.debug_log_path = self.bus_routes_fix_path / 'debug.log'
         self.derived_data_log_path = self.bus_routes_fix_path / 'Notes_for_Visum_Modeller.log'
-        self.list_of_error_modification_paths = [
-                self.modifications_path / f"M{int(error_modification_id):06d}.tra"
-                for error_modification_id in self.error_modification_ids
-            ]
-        self.list_of_scenarios_built_when_adding_each_error_modification = [
-            self.bus_routes_fix_path / f"Scenario_for_M{int(error_modification_id):06d}.ver"
-            for error_modification_id in self.error_modification_ids
-            ]
-        self.list_fixed_error_modification_paths = [
-            self.bus_routes_fix_path / f"Fixed_{int(error_modification_id):06d}.tra"
-            for error_modification_id in self.error_modification_ids
-            ]
+        self.list_of_modification_since_the_1st_error_paths = []
+        self.list_of_scenarios_built_when_adding_each_error_modification = []
+        self.list_fixed_error_modification_paths = []

--- a/bus_routes_fixer/logger_configuration.py
+++ b/bus_routes_fixer/logger_configuration.py
@@ -4,10 +4,12 @@ from datetime import datetime
 
 
 def setup_logger():
-    if not os.path.exists("log"):
-        os.makedirs("log")
+    log_directory = os.path.join(os.getcwd(), 'bus_routes_fixer', 'outputs', 'log')
+    # Check if the directory exists, and create it if it does not
+    if not os.path.exists(log_directory):
+        os.makedirs(log_directory)
     logging.basicConfig(
-        filename=f"log/{datetime.now().strftime('%Y_%m_%d_%H_%M_%S')}_bus_routes_fixer.log",
+        filename=f"bus_routes_fixer/outputs/log/{datetime.now().strftime('%Y_%m_%d_%H_%M_%S')}_bus_routes_fixer.log",
         level=logging.INFO,
         format="[%(asctime)s] {%(pathname)s:%(lineno)d} %(levelname)s - %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",

--- a/bus_routes_fixer/user_run_scripts/user_run.py
+++ b/bus_routes_fixer/user_run_scripts/user_run.py
@@ -6,7 +6,7 @@ Author: Shanshan Xie, Adam Fradgley & Birendra Shrestha
 Adapted from: P6FixBusRoute30.py (Birendra Shrestha)
 
 Instructions:
-- Step 1: Specify 'scenario_management_base_path', 'scenario_management_project_path' 'error_modification_ids' & 'error_scenario_id' in the ../directories.json
+- Step 1: Specify 'scenario_management_base_path', 'scenario_management_project_path' 'first_error_modification_id' & 'error_scenario_id' in the ../directories.json
 - Step 2: Run the main script 'bus_routes_fixer.py'
 """
 


### PR DESCRIPTION
Previously, we classify modifications of the error scenario into 1) pre-error modifications, 2) error modifications and 3) fine modifications after all the error modifications. When adding modifications back, we firstly load modifications pre error, then we delete error routes, then error modifications are loaded without reading data of error routes, subsequently we add fixed error routes back, and finally we load the rest of fine modifications following the last error modification.

However, after fixing error routes, as route items have been changed, the rest modifications, which didn't lead to errors, may cause new errors.

To address these potential new error, now we o.nly classify modifications of the error scenario into modifications before the first error and modifications from the first error. The new procedure of fixing error is firstly load modifications pre error, we then delete error routes, add back the rest of modifications without reading data of error routes, and finally, we add error routes back.